### PR TITLE
25_Read処理のConverter部分実装

### DIFF
--- a/src/main/java/shohei/student/management/controller/StudentController.java
+++ b/src/main/java/shohei/student/management/controller/StudentController.java
@@ -4,24 +4,31 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import shohei.student.management.controller.converter.StudentConverter;
 import shohei.student.management.data.Courses;
 import shohei.student.management.data.Student;
+import shohei.student.management.domain.StudentDetail;
 import shohei.student.management.service.StudentService;
 
 @RestController
 public class StudentController {
 
   private StudentService service;
+  private StudentConverter converter;
 
   @Autowired
-  public StudentController(StudentService service) {
+  public StudentController(StudentService service, StudentConverter converter) {
     this.service = service;
+    this.converter = converter;
   }
 
   @GetMapping("/studentList")
-  public List<Student> getstudentList() {
-    return service.searchStudentsList();
+  public List<StudentDetail> getstudentList() {
+    List<Student> students = service.searchStudentsList();
+    List<Courses> courses = service.searchStudentsCourseList();
+    return converter.convertStudentDetails(students, courses);
   }
+
 
   @GetMapping("/courseList")
   public List<Courses> getCourseList() {

--- a/src/main/java/shohei/student/management/controller/converter/StudentConverter.java
+++ b/src/main/java/shohei/student/management/controller/converter/StudentConverter.java
@@ -1,0 +1,29 @@
+package shohei.student.management.controller.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import shohei.student.management.data.Courses;
+import shohei.student.management.data.Student;
+import shohei.student.management.domain.StudentDetail;
+
+@Component
+public class StudentConverter {
+
+  public List<StudentDetail> convertStudentDetails(List<Student> students,
+      List<Courses> courses) {
+    List<StudentDetail> studentDetails = new ArrayList<>();
+    students.forEach(student -> {
+      StudentDetail studentDetail = new StudentDetail();
+      studentDetail.setStudent(student);
+      List<Courses> convertCourses = courses.stream()
+          .filter(course -> student.getId().equals(course.getStudentId()))
+          .collect(Collectors.toList());
+      studentDetail.setStudentCourses(convertCourses);
+      studentDetails.add(studentDetail);
+    });
+    return studentDetails;
+  }
+
+}

--- a/src/main/java/shohei/student/management/data/Student.java
+++ b/src/main/java/shohei/student/management/data/Student.java
@@ -15,6 +15,8 @@ public class Student {
   private String city;
   private int age;
   private String gender;
+  private String remark;
+  private boolean isDeleted;
 
 
 }

--- a/src/main/java/shohei/student/management/domain/StudentDetail.java
+++ b/src/main/java/shohei/student/management/domain/StudentDetail.java
@@ -1,0 +1,16 @@
+package shohei.student.management.domain;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import shohei.student.management.data.Courses;
+import shohei.student.management.data.Student;
+
+@Getter
+@Setter
+public class StudentDetail {
+
+  private Student student;
+  private List<Courses> studentCourses;
+
+}

--- a/src/main/java/shohei/student/management/service/StudentService.java
+++ b/src/main/java/shohei/student/management/service/StudentService.java
@@ -1,7 +1,6 @@
 package shohei.student.management.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import shohei.student.management.data.Courses;
@@ -20,17 +19,11 @@ public class StudentService {
   }
 
   public List<Student> searchStudentsList() {
-    List<Student> allStudents = repository.search();
-
-    return allStudents.stream()
-        .filter(student -> !(student.getAge() < 30 || student.getAge() >= 40))
-        .collect(Collectors.toList());
+    return repository.search();
   }
 
   public List<Courses> searchStudentsCourseList() {
-    List<Courses> allCoursesData = repository.searchCourses();
-    return allCoursesData.stream()
-        .filter(courses -> courses.getCourseName().equals("Java")).collect(Collectors.toList());
+    return repository.searchCourses();
   }
 
 }


### PR DESCRIPTION
Read処理において、StudentsテーブルのidとStudent_coursesテーブルのstudent_idが一致する組み合わせを探す。受講生情報にコース情報が紐づけられている状態で表示できるよう、Converter部分を実装した。

DBとcurlコマンドの結果
![スクリーンショット 2025-04-21 103838](https://github.com/user-attachments/assets/6232ee0a-d030-41fd-8bf4-4ddc18209fdd)
![スクリーンショット 2025-04-21 103849](https://github.com/user-attachments/assets/88497889-6c97-48ac-9dc8-53d248d9bb4a)
![スクリーンショット 2025-04-21 103909](https://github.com/user-attachments/assets/d0cd9cd1-3654-4e00-8d9b-5b172178e5fc)
