### PR TITLE
HTML th:eachやth:textがうまく動作しない

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,10 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:3.4.4'
     //便利機能、ユーティリティ
     implementation 'org.apache.commons:commons-lang3:3.17.0'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/shohei/student/management/controller/StudentController.java
+++ b/src/main/java/shohei/student/management/controller/StudentController.java
@@ -2,15 +2,15 @@ package shohei.student.management.controller;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 import shohei.student.management.controller.converter.StudentConverter;
 import shohei.student.management.data.Courses;
 import shohei.student.management.data.Student;
-import shohei.student.management.domain.StudentDetail;
 import shohei.student.management.service.StudentService;
 
-@RestController
+@Controller
 public class StudentController {
 
   private StudentService service;
@@ -23,10 +23,11 @@ public class StudentController {
   }
 
   @GetMapping("/studentList")
-  public List<StudentDetail> getstudentList() {
+  public String getstudentList(Model model) {
     List<Student> students = service.searchStudentsList();
     List<Courses> courses = service.searchStudentsCourseList();
-    return converter.convertStudentDetails(students, courses);
+    model.addAttribute("studentList", converter.convertStudentDetails(students, courses));
+    return "studentList";
   }
 
 

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生情報一覧</title>
+</head>
+<body>
+<h1>受講生情報一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>ふりがな</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>地域</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>備考</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail:${studentList}">
+    <td th:text="$studentDetail.student.id}">001</td>
+    <td th:text="$studentDetail.student.name}">近本光司</td>
+    <td th:text="$studentDetail.student.furigana}">ちかもとこうじ</td>
+    <td th:text="$studentDetail.student.nickname}">ちか</td>
+    <td th:text="$studentDetail.student.mail}">KoujiChikamoto@gmail.com</td>
+    <td th:text="$studentDetail.student.city}">兵庫</td>
+    <td th:text="$studentDetail.student.age}">30</td>
+    <td th:text="$studentDetail.student.gender}">male</td>
+    <td th:text="$studentDetail.student.remark}">特になし</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.w3.org/1999/xhtml" lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生情報一覧</title>
+</head>
+<body>
+<h1>受講生情報一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>ふりがな</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>地域</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>備考</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail:${studentList}">
+    <td th:text="$studentDetail.student.id}">001</td>
+    <td th:text="$studentDetail.student.name}">近本光司</td>
+    <td th:text="$studentDetail.student.furigana}">ちかもとこうじ</td>
+    <td th:text="$studentDetail.student.nickname}">ちか</td>
+    <td th:text="$studentDetail.student.mail}">KoujiChikamoto@gmail.com</td>
+    <td th:text="$studentDetail.student.city}">兵庫</td>
+    <td th:text="$studentDetail.student.age}">30</td>
+    <td th:text="$studentDetail.student.gender}">male</td>
+    <td th:text="$studentDetail.student.remark}">特になし</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
警告メッセージとして、
「必須lang属性の欠落」「URLが未登録です(設定｜言語＆フレームワーク｜スキーマとDTD)」「廃止された属性」とでてきている。
調べた結果、thymeleafのプラグインはIntelliJ IDEA Community editionでは、非対応。Ultimate editionは対応している。

Geminiに聞いてみたり、[discordでの検索結果](https://discordapp.com/channels/1065656993194459211/1126618182619254814/1291952600211656765)をもとに設定をいじってみた。
![スクリーンショット 2025-04-22 220038](https://github.com/user-attachments/assets/39aac0e6-de9d-4e5d-86ef-d9bf6e453404)
![スクリーンショット 2025-04-22 220233](https://github.com/user-attachments/assets/09606b94-02cf-4bba-9611-165cdf2db720)
また、「カスタムhtml属性に追加」をしたら読み込んではいるようだが、正しく反応はしなかった。

IntelliJ上で実行結果を表示したら、このように表示された。
![スクリーンショット 2025-04-22 215049](https://github.com/user-attachments/assets/74e39b84-7763-48e8-b2c2-b3edb9d81b57)


アプリケーション実行にあたってはコンパイルエラーはないものの、Webで確認すると以下のようにエラーメッセージが表示された。
![スクリーンショット 2025-04-22 215302](https://github.com/user-attachments/assets/31ced773-120d-4335-a657-f569239227fd)


StudentControllerクラスで、
`    model.addAttribute("studentList", converter.convertStudentDetails(students, courses));
`
の"studentList"にカーソルを合わせてctrl+Bを押したが、「移動先となる宣言が見つかりません」と表示される。