### PR TITLE
27&28_Thymeleafを使ったRead処理とPOST処理の実装

### DIFF
--- a/src/main/java/shohei/student/management/controller/StudentController.java
+++ b/src/main/java/shohei/student/management/controller/StudentController.java
@@ -4,36 +4,95 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import shohei.student.management.controller.converter.StudentConverter;
 import shohei.student.management.data.Courses;
 import shohei.student.management.data.Student;
+import shohei.student.management.domain.StudentDetail;
+import shohei.student.management.repository.StudentRepository;
 import shohei.student.management.service.StudentService;
 
 @Controller
 public class StudentController {
 
-  private StudentService service;
-  private StudentConverter converter;
-
   @Autowired
-  public StudentController(StudentService service, StudentConverter converter) {
-    this.service = service;
-    this.converter = converter;
-  }
+  private StudentService service;
+  @Autowired
+  private StudentConverter converter;
+  @Autowired
+  private StudentRepository repository;
 
+
+  //受講生情報を表示
   @GetMapping("/studentList")
-  public String getstudentList(Model model) {
+  public String getStudentList(Model model) {
     List<Student> students = service.searchStudentsList();
     List<Courses> courses = service.searchStudentsCourseList();
     model.addAttribute("studentList", converter.convertStudentDetails(students, courses));
+    model.addAttribute("courseList", courses);
+
     return "studentList";
   }
 
-
+  //コース情報を表示
   @GetMapping("/courseList")
-  public List<Courses> getCourseList() {
-    return service.searchStudentsCourseList();
+  public String getCourseListByStudentId(@RequestParam("studentId") String studentId, Model model) {
+    List<Courses> courses = service.searchCoursesByStudentId(studentId);
+    model.addAttribute("courseList", courses);
+    model.addAttribute("studentId", studentId);
+    return "courseList";
+  }
+
+  //受講生情報を登録したのち、コース情報を登録する。
+  @GetMapping("/newStudent")
+  public String newStudent(Model model) {
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(new Student());
+    studentDetail.setCourses(new Courses());
+    model.addAttribute("studentDetail", studentDetail);
+    return "registerStudent";
+  }
+
+  @PostMapping("/registerStudent")
+  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "registerStudent";
+    }
+    repository.registerStudent(studentDetail.getStudent().getId(),
+        studentDetail.getStudent().getName(), studentDetail.getStudent().getFurigana(),
+        studentDetail.getStudent().getNickname(), studentDetail.getStudent().getMail(),
+        studentDetail.getStudent().getCity(),
+        studentDetail.getStudent().getAge(), studentDetail.getStudent().getGender(),
+        studentDetail.getStudent().getRemark());
+    String registeredStudentId = studentDetail.getStudent().getId();
+    return "redirect:/newCourse?studentId=" + registeredStudentId;
+  }
+
+
+  @GetMapping("/newCourse")
+  public String newCourse(@RequestParam(value = "studentId", required = false) String studentId,
+      Model model) {
+    Courses courses = new Courses();
+    courses.setStudentId(studentId);
+    model.addAttribute("courses", courses);
+    return "registerCourse";
+  }
+
+
+  @PostMapping("/registerCourse")
+  public String registerCourse(@ModelAttribute Courses courses, BindingResult result) {
+    if (result.hasErrors()) {
+      return "registerCourse";
+    }
+
+    repository.registerCourse(courses.getCourseId(), courses.getStudentId(),
+        courses.getCourseName(), courses.getWhenStart(), courses.getWhenComplete());
+    return "redirect:/studentList";
+
   }
 
 

--- a/src/main/java/shohei/student/management/controller/StudentController.java
+++ b/src/main/java/shohei/student/management/controller/StudentController.java
@@ -50,10 +50,7 @@ public class StudentController {
   //受講生情報を登録したのち、コース情報を登録する。
   @GetMapping("/newStudent")
   public String newStudent(Model model) {
-    StudentDetail studentDetail = new StudentDetail();
-    studentDetail.setStudent(new Student());
-    studentDetail.setCourses(new Courses());
-    model.addAttribute("studentDetail", studentDetail);
+    model.addAttribute("studentDetail", new StudentDetail());
     return "registerStudent";
   }
 
@@ -62,12 +59,8 @@ public class StudentController {
     if (result.hasErrors()) {
       return "registerStudent";
     }
-    repository.registerStudent(studentDetail.getStudent().getId(),
-        studentDetail.getStudent().getName(), studentDetail.getStudent().getFurigana(),
-        studentDetail.getStudent().getNickname(), studentDetail.getStudent().getMail(),
-        studentDetail.getStudent().getCity(),
-        studentDetail.getStudent().getAge(), studentDetail.getStudent().getGender(),
-        studentDetail.getStudent().getRemark());
+
+    repository.registerStudent(studentDetail.getStudent());
     String registeredStudentId = studentDetail.getStudent().getId();
     return "redirect:/newCourse?studentId=" + registeredStudentId;
   }
@@ -76,8 +69,7 @@ public class StudentController {
   @GetMapping("/newCourse")
   public String newCourse(@RequestParam(value = "studentId", required = false) String studentId,
       Model model) {
-    Courses courses = new Courses();
-    courses.setStudentId(studentId);
+    Courses courses = new Courses(studentId);
     model.addAttribute("courses", courses);
     return "registerCourse";
   }

--- a/src/main/java/shohei/student/management/controller/StudentController.java
+++ b/src/main/java/shohei/student/management/controller/StudentController.java
@@ -50,10 +50,7 @@ public class StudentController {
   //受講生情報を登録したのち、コース情報を登録する。
   @GetMapping("/newStudent")
   public String newStudent(Model model) {
-    StudentDetail studentDetail = new StudentDetail();
-    studentDetail.setStudent(new Student());
-    studentDetail.setCourses(new Courses());
-    model.addAttribute("studentDetail", studentDetail);
+    model.addAttribute("studentDetail", new StudentDetail());
     return "registerStudent";
   }
 
@@ -62,12 +59,8 @@ public class StudentController {
     if (result.hasErrors()) {
       return "registerStudent";
     }
-    repository.registerStudent(studentDetail.getStudent().getId(),
-        studentDetail.getStudent().getName(), studentDetail.getStudent().getFurigana(),
-        studentDetail.getStudent().getNickname(), studentDetail.getStudent().getMail(),
-        studentDetail.getStudent().getCity(),
-        studentDetail.getStudent().getAge(), studentDetail.getStudent().getGender(),
-        studentDetail.getStudent().getRemark());
+
+    repository.registerStudent(studentDetail.getStudent());
     String registeredStudentId = studentDetail.getStudent().getId();
     return "redirect:/newCourse?studentId=" + registeredStudentId;
   }
@@ -76,8 +69,7 @@ public class StudentController {
   @GetMapping("/newCourse")
   public String newCourse(@RequestParam(value = "studentId", required = false) String studentId,
       Model model) {
-    Courses courses = new Courses();
-    courses.setStudentId(studentId);
+    Courses courses = new Courses(studentId);
     model.addAttribute("courses", courses);
     return "registerCourse";
   }
@@ -89,8 +81,7 @@ public class StudentController {
       return "registerCourse";
     }
 
-    repository.registerCourse(courses.getCourseId(), courses.getStudentId(),
-        courses.getCourseName(), courses.getWhenStart(), courses.getWhenComplete());
+    repository.registerCourse(courses);
     return "redirect:/studentList";
 
   }

--- a/src/main/java/shohei/student/management/controller/converter/StudentConverter.java
+++ b/src/main/java/shohei/student/management/controller/converter/StudentConverter.java
@@ -14,15 +14,16 @@ public class StudentConverter {
   public List<StudentDetail> convertStudentDetails(List<Student> students,
       List<Courses> courses) {
     List<StudentDetail> studentDetails = new ArrayList<>();
-    students.forEach(student -> {
+    for (Student student : students) {
       StudentDetail studentDetail = new StudentDetail();
       studentDetail.setStudent(student);
-      List<Courses> convertCourses = courses.stream()
+      List<Courses> list = courses.stream()
           .filter(course -> student.getId().equals(course.getStudentId()))
           .collect(Collectors.toList());
+      List<Courses> convertCourses = list;
       studentDetail.setStudentCourses(convertCourses);
       studentDetails.add(studentDetail);
-    });
+    }
     return studentDetails;
   }
 

--- a/src/main/java/shohei/student/management/data/Courses.java
+++ b/src/main/java/shohei/student/management/data/Courses.java
@@ -14,5 +14,13 @@ public class Courses {
   private LocalDateTime whenStart;
   private LocalDateTime whenComplete;
 
+  public Courses(String studentId) {
+    this.studentId = studentId;
+  }
+
+  public Courses() {
+
+  }
+
 
 }

--- a/src/main/java/shohei/student/management/domain/StudentDetail.java
+++ b/src/main/java/shohei/student/management/domain/StudentDetail.java
@@ -12,5 +12,6 @@ public class StudentDetail {
 
   private Student student;
   private List<Courses> studentCourses;
+  private Courses courses;
 
 }

--- a/src/main/java/shohei/student/management/domain/StudentDetail.java
+++ b/src/main/java/shohei/student/management/domain/StudentDetail.java
@@ -14,4 +14,13 @@ public class StudentDetail {
   private List<Courses> studentCourses;
   private Courses courses;
 
+  public StudentDetail(Student student, Courses courses) {
+    this.student = student;
+    this.courses = courses;
+  }
+  
+
+  public StudentDetail() {
+    this(new Student(), new Courses());
+  }
 }

--- a/src/main/java/shohei/student/management/repository/StudentRepository.java
+++ b/src/main/java/shohei/student/management/repository/StudentRepository.java
@@ -1,7 +1,10 @@
 package shohei.student.management.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 import shohei.student.management.data.Courses;
 import shohei.student.management.data.Student;
@@ -26,6 +29,18 @@ public interface StudentRepository {
 
   @Select("SELECT * FROM students_courses")
   List<Courses> searchCourses();
+
+  @Select("SELECT * FROM students_courses WHERE student_id = #{studentId}")
+  List<Courses> findCourses(@Param("studentId") String studentId);
+
+
+  @Insert("INSERT INTO students (id, name, furigana, nickname, mail, city, age, gender, remark) VALUES(#{id}, #{name}, #{furigana}, #{nickname}, #{mail}, #{city}, #{age}, #{gender}, #{remark})")
+  void registerStudent(String id, String name, String furigana, String nickname, String mail,
+      String city, int age, String gender, String remark);
+
+  @Insert("INSERT INTO  students_courses VALUES(#{courseId}, #{studentId}, #{courseName}, #{whenStart}, #{whenComplete})")
+  void registerCourse(String courseId, String studentId, String courseName, LocalDateTime whenStart,
+      LocalDateTime whenComplete);
 
 
 }

--- a/src/main/java/shohei/student/management/repository/StudentRepository.java
+++ b/src/main/java/shohei/student/management/repository/StudentRepository.java
@@ -35,8 +35,7 @@ public interface StudentRepository {
 
 
   @Insert("INSERT INTO students (id, name, furigana, nickname, mail, city, age, gender, remark) VALUES(#{id}, #{name}, #{furigana}, #{nickname}, #{mail}, #{city}, #{age}, #{gender}, #{remark})")
-  void registerStudent(String id, String name, String furigana, String nickname, String mail,
-      String city, int age, String gender, String remark);
+  void registerStudent(Student student);
 
   @Insert("INSERT INTO  students_courses VALUES(#{courseId}, #{studentId}, #{courseName}, #{whenStart}, #{whenComplete})")
   void registerCourse(String courseId, String studentId, String courseName, LocalDateTime whenStart,

--- a/src/main/java/shohei/student/management/repository/StudentRepository.java
+++ b/src/main/java/shohei/student/management/repository/StudentRepository.java
@@ -1,6 +1,5 @@
 package shohei.student.management.repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
@@ -35,12 +34,10 @@ public interface StudentRepository {
 
 
   @Insert("INSERT INTO students (id, name, furigana, nickname, mail, city, age, gender, remark) VALUES(#{id}, #{name}, #{furigana}, #{nickname}, #{mail}, #{city}, #{age}, #{gender}, #{remark})")
-  void registerStudent(String id, String name, String furigana, String nickname, String mail,
-      String city, int age, String gender, String remark);
+  void registerStudent(Student student);
 
   @Insert("INSERT INTO  students_courses VALUES(#{courseId}, #{studentId}, #{courseName}, #{whenStart}, #{whenComplete})")
-  void registerCourse(String courseId, String studentId, String courseName, LocalDateTime whenStart,
-      LocalDateTime whenComplete);
+  void registerCourse(Courses courses);
 
 
 }

--- a/src/main/java/shohei/student/management/service/StudentService.java
+++ b/src/main/java/shohei/student/management/service/StudentService.java
@@ -26,4 +26,9 @@ public class StudentService {
     return repository.searchCourses();
   }
 
+  public List<Courses> searchCoursesByStudentId(String studentId) {
+    return repository.findCourses(studentId);
+  }
+
+
 }

--- a/src/main/resources/templates/courseList.html
+++ b/src/main/resources/templates/courseList.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>コース情報一覧</title>
+</head>
+<body>
+<h1>コース情報一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>コースID</th>
+    <th>受講生ID</th>
+    <th>コース名</th>
+    <th>受講開始</th>
+    <th>受講終了予定</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="course : ${courseList}">
+    <td th:text="${course.courseId}">001</td>
+    <td th:text="${course.studentId}">近本光司</td>
+    <td th:text="${course.courseName}">ちかもとこうじ</td>
+    <td th:text="${course.whenStart}">2025-05-01</td>
+    <td th:text="${course.whenComplete}">2025-06-30</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/registerCourse.html
+++ b/src/main/resources/templates/registerCourse.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>コース情報登録</title>
+</head>
+<body>
+<h1>コース情報登録</h1>
+<form th:action="@{/registerCourse}" th:object="${courses}" method="post">
+  <div>
+    <label for="courseId">コースID:</label>
+    <input type="text" id="courseId" th:field="*{courseId}" required/>
+    <label for="studentId">受講生ID:</label>
+    <input type="text" id="studentId" th:field="*{studentId}" readonly/>
+    <label for="furigana">コース名:</label>
+    <input type="text" id="furigana" th:field="*{courseName}" required/>
+    <label for="nickname">受講開始:</label>
+    <input type="text" id="nickname" th:field="*{whenStart}" required/>
+    <label for="mail">受講終了予定:</label>
+    <input type="text" id="mail" th:field="*{whenComplete}" required/>
+  </div>
+  <div>
+    <button type="submit">登録</button>
+  </div>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/registerCourse.html
+++ b/src/main/resources/templates/registerCourse.html
@@ -6,18 +6,16 @@
 <body>
 <h1>コース情報登録</h1>
 <form th:action="@{/registerCourse}" th:object="${courses}" method="post">
-  <div>
-    <label for="courseId">コースID:</label>
-    <input type="text" id="courseId" th:field="*{courseId}" required/>
-    <label for="studentId">受講生ID:</label>
-    <input type="text" id="studentId" th:field="*{studentId}" readonly/>
-    <label for="furigana">コース名:</label>
-    <input type="text" id="furigana" th:field="*{courseName}" required/>
-    <label for="nickname">受講開始:</label>
-    <input type="text" id="nickname" th:field="*{whenStart}" required/>
-    <label for="mail">受講終了予定:</label>
-    <input type="text" id="mail" th:field="*{whenComplete}" required/>
-  </div>
+  <div style="width: 200px;"><label for="courseId">コースID:</label>
+    <input type="text" id="courseId" th:field="*{courseId}" required/></div>
+  <div style="width: 200px;"><label for="studentId">受講生ID:</label>
+    <input type="text" id="studentId" th:field="*{studentId}" readonly/></div>
+  <div style="width: 200px;"><label for="furigana">コース名:</label>
+    <input type="text" id="furigana" th:field="*{courseName}" required/></div>
+  <div style="width: 200px;"><label for="nickname">受講開始:</label>
+    <input type="text" id="nickname" th:field="*{whenStart}" required/></div>
+  <div style="width: 200px;"><label for="mail">受講終了予定:</label>
+    <input type="text" id="mail" th:field="*{whenComplete}" required/></div>
   <div>
     <button type="submit">登録</button>
   </div>

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>受講生登録</title>
+</head>
+<body>
+<h1>受講生登録</h1>
+<form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="id">ID:</label>
+    <input type="text" id="id" th:field="*{student.id}" required/>
+    <label for="name">名前:</label>
+    <input type="text" id="name" th:field="*{student.name}" required/>
+    <label for="furigana">ふりがな:</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
+    <label for="nickname">ニックネーム:</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}" required/>
+    <label for="mail">メールアドレス:</label>
+    <input type="text" id="mail" th:field="*{student.mail}" required/>
+    <label for="city">出身地（市区町村）:</label>
+    <input type="text" id="city" th:field="*{student.city}" required/>
+    <label for="age">年齢:</label>
+    <input type="number" id="age" th:field="*{student.age}" required/>
+    <label for="gender">性別:</label>
+    <input type="text" id="gender" th:field="*{student.gender}" required/>
+    <label for="remark">備考:</label>
+    <input type="text" id="remark" th:field="*{student.remark}" required/>
+  </div>
+  <div>
+    <button type="submit">登録</button>
+  </div>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -6,24 +6,25 @@
 <body>
 <h1>受講生登録</h1>
 <form th:action="@{/registerStudent}" th:object="${studentDetail}" method="post">
-  <div>
+  <div style="width: 200px;">
     <label for="id">ID:</label>
     <input type="text" id="id" th:field="*{student.id}" required/>
-    <label for="name">名前:</label>
-    <input type="text" id="name" th:field="*{student.name}" required/>
-    <label for="furigana">ふりがな:</label>
-    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
-    <label for="nickname">ニックネーム:</label>
-    <input type="text" id="nickname" th:field="*{student.nickname}" required/>
-    <label for="mail">メールアドレス:</label>
-    <input type="text" id="mail" th:field="*{student.mail}" required/>
-    <label for="city">出身地（市区町村）:</label>
-    <input type="text" id="city" th:field="*{student.city}" required/>
-    <label for="age">年齢:</label>
-    <input type="number" id="age" th:field="*{student.age}" required/>
-    <label for="gender">性別:</label>
-    <input type="text" id="gender" th:field="*{student.gender}" required/>
-    <label for="remark">備考:</label>
+  </div>
+  <div style="width: 200px;"><label for="name">名前:</label>
+    <input type="text" id="name" th:field="*{student.name}" required/></div>
+  <div style="width: 200px;"><label for="furigana">ふりがな:</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/></div>
+  <div style="width: 200px;"><label for="nickname">ニックネーム:</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}" required/></div>
+  <div style="width: 200px;"><label for="mail">メールアドレス:</label>
+    <input type="text" id="mail" th:field="*{student.mail}" required/></div>
+  <div style="width: 200px;"><label for="city">出身地（市区町村）:</label>
+    <input type="text" id="city" th:field="*{student.city}" required/></div>
+  <div style="width: 200px;"><label for="age">年齢:</label>
+    <input type="number" id="age" th:field="*{student.age}" required/></div>
+  <div style="width: 200px;"><label for="gender">性別:</label>
+    <input type="text" id="gender" th:field="*{student.gender}" required/></div>
+  <div style="width: 200px;"><label for="remark">備考:</label>
     <input type="text" id="remark" th:field="*{student.remark}" required/>
   </div>
   <div>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
   <meta charset="UTF-8">
   <title>受講生情報一覧</title>
@@ -22,15 +22,42 @@
   </thead>
   <tbody>
   <tr th:each="studentDetail:${studentList}">
-    <td th:text="$studentDetail.student.id}">001</td>
-    <td th:text="$studentDetail.student.name}">近本光司</td>
-    <td th:text="$studentDetail.student.furigana}">ちかもとこうじ</td>
-    <td th:text="$studentDetail.student.nickname}">ちか</td>
-    <td th:text="$studentDetail.student.mail}">KoujiChikamoto@gmail.com</td>
-    <td th:text="$studentDetail.student.city}">兵庫</td>
-    <td th:text="$studentDetail.student.age}">30</td>
-    <td th:text="$studentDetail.student.gender}">male</td>
-    <td th:text="$studentDetail.student.remark}">特になし</td>
+    <td th:text="${studentDetail.student.id}">001</td>
+    <td th:text="${studentDetail.student.name}">近本光司</td>
+    <td th:text="${studentDetail.student.furigana}">ちかもとこうじ</td>
+    <td th:text="${studentDetail.student.nickname}">ちか</td>
+    <td th:text="${studentDetail.student.mail}">KoujiChikamoto@gmail.com</td>
+    <td th:text="${studentDetail.student.city}">兵庫</td>
+    <td th:text="${studentDetail.student.age}">30</td>
+    <td th:text="${studentDetail.student.gender}">male</td>
+    <td th:text="${studentDetail.student.remark}">特になし</td>
+    <td>
+      <a th:href="@{/newCourse(studentId=${studentDetail.student.id})}">コース追加</a>
+      <a th:href="@{/courseList(studentId=${studentDetail.student.id})}">受講コース一覧</a>
+    </td>
+  </tr>
+
+
+  </tbody>
+</table>
+<h1>コース情報一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>コースID</th>
+    <th>受講生ID</th>
+    <th>コース名</th>
+    <th>受講開始</th>
+    <th>受講終了予定</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="course : ${courseList}">
+    <td th:text="${course.courseId}">001</td>
+    <td th:text="${course.studentId}">近本光司</td>
+    <td th:text="${course.courseName}">ちかもとこうじ</td>
+    <td th:text="${course.whenStart}">2025-05-01</td>
+    <td th:text="${course.whenComplete}">2025-06-30</td>
   </tr>
   </tbody>
 </table>


### PR DESCRIPTION
[http://localhost:8080/studentList](url)
で受講生情報一覧とコース情報一覧を表示

「コース追加」をクリックすると、コースのみを追加できるようにした。
「受講コース一覧」をクリックすると、画面が遷移し、その受講生が受講しているコースの一覧が表示されるようにした。

[http://localhost:8080/newStudent](url)
では、まず受講生情報のみを入力する。登録を押すと、コース情報の登録画面に遷移、コース情報の登録をする。ただし、その画面では、前の画面で入力済みの受講生IDが自動で反映され、ユーザーが受講生IDを変更できないようにしてある。


https://github.com/user-attachments/assets/9f0d4ffd-b73a-4941-aca3-e6e79eb42e67

![スクリーンショット 2025-04-28 105230](https://github.com/user-attachments/assets/ec5e626a-21d2-4d85-80fb-b7b73d00d22e)
